### PR TITLE
Added password info for 'sa' account

### DIFF
--- a/docker-compose.windows.yml
+++ b/docker-compose.windows.yml
@@ -13,6 +13,7 @@ services:
       dockerfile: Dockerfile.windows
     environment:
       - "Data:DefaultConnection:ConnectionString=Server=db,1433;Database=MusicStore;User Id=sa;Password=Password1;MultipleActiveResultSets=True"
+      - "sa_password=Password1"
     depends_on:
       - "db"
     ports:


### PR DESCRIPTION
According to the [docs](https://hub.docker.com/r/microsoft/mssql-server-2016-express-windows/) for the microsoft/mssql-server-2016-express-windows image, the sa_password environment variable is needed in order to set the sa password to the desired value. I'm not sure what the default password is, but it doesn't seem to be Password1, so the example didn't work until I added this.
