### PR TITLE
Pin references and fix breaking changes from deps

### DIFF
--- a/samples/MusicStore/ForTesting/Mocks/Facebook/TestFacebookEvents.cs
+++ b/samples/MusicStore/ForTesting/Mocks/Facebook/TestFacebookEvents.cs
@@ -17,11 +17,6 @@ namespace MusicStore.Mocks.Facebook
             if (context.Ticket.Principal != null)
             {
                 Helpers.ThrowIfConditionFailed(() => context.AccessToken == "ValidAccessToken", "");
-                Helpers.ThrowIfConditionFailed(() => FacebookHelper.GetEmail(context.User) == "AspnetvnextTest@test.com", "");
-                Helpers.ThrowIfConditionFailed(() => FacebookHelper.GetId(context.User) == "Id", "");
-                Helpers.ThrowIfConditionFailed(() => FacebookHelper.GetLink(context.User) == "https://www.facebook.com/myLink", "");
-                Helpers.ThrowIfConditionFailed(() => FacebookHelper.GetName(context.User) == "AspnetvnextTest AspnetvnextTest", "");
-                Helpers.ThrowIfConditionFailed(() => context.User.SelectToken("id").ToString() == FacebookHelper.GetId(context.User), "");
                 Helpers.ThrowIfConditionFailed(() => context.ExpiresIn.Value == TimeSpan.FromSeconds(100), "");
                 Helpers.ThrowIfConditionFailed(() => context.AccessToken == "ValidAccessToken", "");
                 context.Ticket.Principal.Identities.First().AddClaim(new Claim("ManageStore", "false"));

--- a/samples/MusicStore/ForTesting/Mocks/Google/TestGoogleEvents.cs
+++ b/samples/MusicStore/ForTesting/Mocks/Google/TestGoogleEvents.cs
@@ -19,9 +19,6 @@ namespace MusicStore.Mocks.Google
                 Helpers.ThrowIfConditionFailed(() => context.AccessToken == "ValidAccessToken", "Access token is not valid");
                 Helpers.ThrowIfConditionFailed(() => context.RefreshToken == "ValidRefreshToken", "Refresh token is not valid");
                 Helpers.ThrowIfConditionFailed(() => GoogleHelper.GetEmail(context.User) == "AspnetvnextTest@gmail.com", "Email is not valid");
-                Helpers.ThrowIfConditionFailed(() => GoogleHelper.GetId(context.User) == "106790274378320830963", "Id is not valid");
-                Helpers.ThrowIfConditionFailed(() => GoogleHelper.GetFamilyName(context.User) == "AspnetvnextTest", "FamilyName is not valid");
-                Helpers.ThrowIfConditionFailed(() => GoogleHelper.GetName(context.User) == "AspnetvnextTest AspnetvnextTest", "Name is not valid");
                 Helpers.ThrowIfConditionFailed(() => context.ExpiresIn.Value == TimeSpan.FromSeconds(1200), "ExpiresIn is not valid");
                 Helpers.ThrowIfConditionFailed(() => context.User != null, "User object is not valid");
                 context.Ticket.Principal.Identities.First().AddClaim(new Claim("ManageStore", "false"));

--- a/samples/MusicStore/ForTesting/Mocks/MicrosoftAccount/TestMicrosoftAccountEvents.cs
+++ b/samples/MusicStore/ForTesting/Mocks/MicrosoftAccount/TestMicrosoftAccountEvents.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Authentication.MicrosoftAccount;
 using Microsoft.AspNetCore.Authentication.OAuth;
 using Microsoft.AspNetCore.Identity;
 using MusicStore.Mocks.Common;
@@ -18,13 +17,8 @@ namespace MusicStore.Mocks.MicrosoftAccount
             {
                 Helpers.ThrowIfConditionFailed(() => context.AccessToken == "ValidAccessToken", "Access token is not valid");
                 Helpers.ThrowIfConditionFailed(() => context.RefreshToken == "ValidRefreshToken", "Refresh token is not valid");
-                Helpers.ThrowIfConditionFailed(() => MicrosoftAccountHelper.GetGivenName(context.User) == "AspnetvnextTest", "Given name is not valid");
-                Helpers.ThrowIfConditionFailed(() => MicrosoftAccountHelper.GetSurname(context.User) == "AspnetvnextTest", "Surname is not valid");
-                Helpers.ThrowIfConditionFailed(() => MicrosoftAccountHelper.GetId(context.User) == "fccf9a24999f4f4f", "Id is not valid");
-                Helpers.ThrowIfConditionFailed(() => MicrosoftAccountHelper.GetDisplayName(context.User) == "AspnetvnextTest AspnetvnextTest", "Name is not valid");
                 Helpers.ThrowIfConditionFailed(() => context.ExpiresIn.Value == TimeSpan.FromSeconds(3600), "ExpiresIn is not valid");
                 Helpers.ThrowIfConditionFailed(() => context.User != null, "User object is not valid");
-                Helpers.ThrowIfConditionFailed(() => MicrosoftAccountHelper.GetId(context.User) == context.User.SelectToken("id").ToString(), "User id is not valid");
                 context.Ticket.Principal.Identities.First().AddClaim(new Claim("ManageStore", "false"));
             }
 

--- a/samples/MusicStore/ForTesting/Mocks/StartupOpenIdConnectTesting.cs
+++ b/samples/MusicStore/ForTesting/Mocks/StartupOpenIdConnectTesting.cs
@@ -45,7 +45,7 @@ namespace MusicStore
             if (_platform.UseInMemoryStore)
             {
                 services.AddDbContext<MusicStoreContext>(options =>
-                            options.UseInMemoryDatabase());
+                            options.UseInMemoryDatabase("MusicStore"));
             }
             else
             {

--- a/samples/MusicStore/ForTesting/Mocks/StartupSocialTesting.cs
+++ b/samples/MusicStore/ForTesting/Mocks/StartupSocialTesting.cs
@@ -50,7 +50,7 @@ namespace MusicStore
             if (_platform.UseInMemoryStore)
             {
                 services.AddDbContext<MusicStoreContext>(options =>
-                            options.UseInMemoryDatabase());
+                            options.UseInMemoryDatabase("MusicStore"));
             }
             else
             {

--- a/samples/MusicStore/MusicStore.csproj
+++ b/samples/MusicStore/MusicStore.csproj
@@ -14,24 +14,24 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore" Version="1.2.0-*" />
-    <PackageReference Include="Microsoft.AspNetCore.AspNetCoreModule" Version="1.0.0-*" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="1.2.0-*" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="1.2.0-*" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="1.2.0-*" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="1.2.0-*" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="1.2.0-*" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Twitter" Version="1.2.0-*" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="1.2.0-*" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="1.2.0-*" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="1.2.0-*" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.2.0-*" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.HttpSys" Version="1.2.0-*" />
-    <PackageReference Include="Microsoft.AspNetCore.Session" Version="1.2.0-*" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.2.0-*" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="1.2.0-*" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="1.2.0-*" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="1.2.0-*" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="1.2.0-preview1-23881 " />
+    <PackageReference Include="Microsoft.AspNetCore.AspNetCoreModule" Version="1.0.0-preview1-10030" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="1.2.0-preview1-23881 " />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="1.2.0-preview1-23881 " />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="1.2.0-preview1-23881 " />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="1.2.0-preview1-23881 " />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="1.2.0-preview1-23881 " />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Twitter" Version="1.2.0-preview1-23881 " />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="1.2.0-preview1-23881 " />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="1.2.0-preview1-23881 " />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="1.2.0-preview1-23881" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.2.0-preview1-23881" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.HttpSys" Version="1.2.0-preview1-23881" />
+    <PackageReference Include="Microsoft.AspNetCore.Session" Version="1.2.0-preview1-23881" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.2.0-preview1-23881" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="1.2.0-preview1-23881" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="1.2.0-preview1-23881" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="1.2.0-preview1-23881" />
   </ItemGroup>
 
 </Project>

--- a/samples/MusicStore/Startup.cs
+++ b/samples/MusicStore/Startup.cs
@@ -39,7 +39,7 @@ namespace MusicStore
             if (_platform.UseInMemoryStore)
             {
                 services.AddDbContext<MusicStoreContext>(options =>
-                    options.UseInMemoryDatabase());
+                    options.UseInMemoryDatabase("MusicStore"));
             }
             else
             {

--- a/samples/MusicStore/StartupOpenIdConnect.cs
+++ b/samples/MusicStore/StartupOpenIdConnect.cs
@@ -57,7 +57,7 @@ namespace MusicStore
             if (_platform.UseInMemoryStore)
             {
                 services.AddDbContext<MusicStoreContext>(options =>
-                            options.UseInMemoryDatabase());
+                            options.UseInMemoryDatabase("MusicStore"));
             }
             else
             {

--- a/samples/MusicStore/web.config
+++ b/samples/MusicStore/web.config
@@ -4,6 +4,6 @@
     <handlers>
       <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified" />
     </handlers>
-    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="true" />
+    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false" />
   </system.webServer>
 </configuration>

--- a/test/MusicStore.Test/CartSummaryComponentTest.cs
+++ b/test/MusicStore.Test/CartSummaryComponentTest.cs
@@ -22,7 +22,7 @@ namespace MusicStore.Components
 
             var services = new ServiceCollection();
 
-            services.AddDbContext<MusicStoreContext>(b => b.UseInMemoryDatabase().UseInternalServiceProvider(efServiceProvider));
+            services.AddDbContext<MusicStoreContext>(b => b.UseInMemoryDatabase("MusicStore").UseInternalServiceProvider(efServiceProvider));
 
             _serviceProvider = services.BuildServiceProvider();
         }

--- a/test/MusicStore.Test/CheckoutControllerTest.cs
+++ b/test/MusicStore.Test/CheckoutControllerTest.cs
@@ -25,7 +25,7 @@ namespace MusicStore.Controllers
 
             var services = new ServiceCollection();
 
-            services.AddDbContext<MusicStoreContext>(b => b.UseInMemoryDatabase().UseInternalServiceProvider(efServiceProvider));
+            services.AddDbContext<MusicStoreContext>(b => b.UseInMemoryDatabase("MusicStore").UseInternalServiceProvider(efServiceProvider));
 
             _serviceProvider = services.BuildServiceProvider();
         }

--- a/test/MusicStore.Test/GenreMenuComponentTest.cs
+++ b/test/MusicStore.Test/GenreMenuComponentTest.cs
@@ -20,7 +20,7 @@ namespace MusicStore.Components
 
             var services = new ServiceCollection();
 
-            services.AddDbContext<MusicStoreContext>(b => b.UseInMemoryDatabase().UseInternalServiceProvider(efServiceProvider));
+            services.AddDbContext<MusicStoreContext>(b => b.UseInMemoryDatabase("MusicStore").UseInternalServiceProvider(efServiceProvider));
 
             _serviceProvider = services.BuildServiceProvider();
         }

--- a/test/MusicStore.Test/HomeControllerTest.cs
+++ b/test/MusicStore.Test/HomeControllerTest.cs
@@ -22,7 +22,7 @@ namespace MusicStore.Controllers
 
             var services = new ServiceCollection();
 
-            services.AddDbContext<MusicStoreContext>(b => b.UseInMemoryDatabase().UseInternalServiceProvider(efServiceProvider));
+            services.AddDbContext<MusicStoreContext>(b => b.UseInMemoryDatabase("MusicStore").UseInternalServiceProvider(efServiceProvider));
 
             _serviceProvider = services.BuildServiceProvider();
         }

--- a/test/MusicStore.Test/ManageControllerTest.cs
+++ b/test/MusicStore.Test/ManageControllerTest.cs
@@ -25,7 +25,7 @@ namespace MusicStore.Controllers
             var services = new ServiceCollection();
             services.AddOptions();
             services
-                .AddDbContext<MusicStoreContext>(b => b.UseInMemoryDatabase().UseInternalServiceProvider(efServiceProvider));
+                .AddDbContext<MusicStoreContext>(b => b.UseInMemoryDatabase("MusicStore").UseInternalServiceProvider(efServiceProvider));
 
             services.AddIdentity<ApplicationUser, IdentityRole>()
                     .AddEntityFrameworkStores<MusicStoreContext>();

--- a/test/MusicStore.Test/Models/ShoppingCartTest.cs
+++ b/test/MusicStore.Test/Models/ShoppingCartTest.cs
@@ -49,7 +49,7 @@ namespace MusicStore.Test
 
             var services = new ServiceCollection();
 
-            services.AddDbContext<MusicStoreContext>(b => b.UseInMemoryDatabase().UseInternalServiceProvider(efServiceProvider));
+            services.AddDbContext<MusicStoreContext>(b => b.UseInMemoryDatabase("MusicStore").UseInternalServiceProvider(efServiceProvider));
 
             _serviceProvider = services.BuildServiceProvider();
         }

--- a/test/MusicStore.Test/ShoppingCartControllerTest.cs
+++ b/test/MusicStore.Test/ShoppingCartControllerTest.cs
@@ -29,7 +29,7 @@ namespace MusicStore.Controllers
             var services = new ServiceCollection();
             services
                 .AddSingleton<ObjectPoolProvider, DefaultObjectPoolProvider>()
-                .AddDbContext<MusicStoreContext>(b => b.UseInMemoryDatabase().UseInternalServiceProvider(efServiceProvider));
+                .AddDbContext<MusicStoreContext>(b => b.UseInMemoryDatabase("MusicStore").UseInternalServiceProvider(efServiceProvider));
 
             services.AddMvc();
 

--- a/test/MusicStore.Test/StoreControllerTest.cs
+++ b/test/MusicStore.Test/StoreControllerTest.cs
@@ -22,7 +22,7 @@ namespace MusicStore.Controllers
 
             var services = new ServiceCollection();
 
-            services.AddDbContext<MusicStoreContext>(b => b.UseInMemoryDatabase().UseInternalServiceProvider(efServiceProvider));
+            services.AddDbContext<MusicStoreContext>(b => b.UseInMemoryDatabase("MusicStore").UseInternalServiceProvider(efServiceProvider));
 
             _serviceProvider = services.BuildServiceProvider();
         }


### PR DESCRIPTION
The ASP.NET Core refs use the CI builds which are changeable. This fixes the current build issues and pins the web app to the current package versions.

Signed-off-by: Elton Stoneman <elton@sixeyed.com>